### PR TITLE
feat(testskeleton.go): introduce UUID generation required by Azure Terratest implementation

### DIFF
--- a/pkg/testskeleton/testskeleton.go
+++ b/pkg/testskeleton/testskeleton.go
@@ -65,7 +65,7 @@ type AzureRandomNames struct {
 	StorageAccountName string
 }
 
-// Function that generates and return a set of random Azure resource names.
+// Function that generates and returns a set of random Azure resource names.
 // Randomization is based on UUID.
 func GenerateAzureRandomNames() AzureRandomNames {
 	id := uuid.New().String()
@@ -79,7 +79,6 @@ func GenerateAzureRandomNames() AzureRandomNames {
 		NamePrefix:         fmt.Sprintf("ghci%s-", prefixId),
 		ResourceGroupName:  strings.Join(gid, ""),
 		StorageAccountName: fmt.Sprintf("ghci%s", strings.Join(storageId, "")),
-		// StorageAccountName: strings.Join(storageId, ""),
 	}
 
 	return names

--- a/pkg/testskeleton/testskeleton.go
+++ b/pkg/testskeleton/testskeleton.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	tfjson "github.com/hashicorp/terraform-json"
@@ -55,6 +56,49 @@ type AdditionalChangesAfterDeployment struct {
 	UseVarFiles          []string
 	FileNameWithTfCode   string
 	ChangedResources     []ChangedResource
+}
+
+// Structure used for Azure deployments - contains randomly generated resource names.
+type AzureRandomNames struct {
+	NamePrefix         string
+	ResourceGroupName  string
+	StorageAccountName string
+}
+
+// Function that generates and return a set of random Azure resource names.
+// Randomization is based on UUID.
+func GenerateAzureRandomNames() AzureRandomNames {
+	id := uuid.New().String()
+	idSliced := strings.Split(id, "-")
+
+	prefixId := idSliced[2]
+	gid := idSliced[0:2]
+	storageId := idSliced[3:5]
+
+	names := AzureRandomNames{
+		NamePrefix:         fmt.Sprintf("ghci%s-", prefixId),
+		ResourceGroupName:  strings.Join(gid, ""),
+		StorageAccountName: fmt.Sprintf("ghci%s", strings.Join(storageId, "")),
+		// StorageAccountName: strings.Join(storageId, ""),
+	}
+
+	return names
+}
+
+// Function running only only code validation.
+func ValidateCode(t *testing.T, terraformOptions *terraform.Options) *terraform.Options {
+	if terraformOptions == nil {
+		terraformOptions = terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+			TerraformDir: ".",
+			Logger:       logger.Default,
+			Lock:         true,
+			Upgrade:      true,
+		})
+	}
+
+	terraform.InitAndValidate(t, terraformOptions)
+
+	return terraformOptions
 }
 
 // Function is responsible for deployment of the infrastructure,


### PR DESCRIPTION
## Description

Introduce UUID generation required by Azure Terratest implementation.

## Motivation and Context

In Azure we relay on UUID as a source of random names for RGs, Storage Accounts and name prefixes. To retain the same logic we had in all pre-Terratest workflows this change is pushed. 

## How Has This Been Tested?

This code is already running on a [PR branch for Azure repo](https://github.com/PaloAltoNetworks/terraform-azurerm-vmseries-modules/pull/278) introducing Terratest in general.

## Types of changes


- New feature (non-breaking change which adds functionality)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.