### PR TITLE
feat: PR ID prefix for azure random names

### DIFF
--- a/pkg/testskeleton/testskeleton.go
+++ b/pkg/testskeleton/testskeleton.go
@@ -68,6 +68,11 @@ type AzureRandomNames struct {
 // Function that generates and returns a set of random Azure resource names.
 // Randomization is based on UUID.
 func GenerateAzureRandomNames() AzureRandomNames {
+	prid := os.Getenv("PRID")
+	if prid != "" {
+		prid = fmt.Sprintf("-pr%s-", prid)
+	}
+
 	id := uuid.New().String()
 	idSliced := strings.Split(id, "-")
 
@@ -76,7 +81,7 @@ func GenerateAzureRandomNames() AzureRandomNames {
 	storageId := idSliced[3:5]
 
 	names := AzureRandomNames{
-		NamePrefix:         fmt.Sprintf("ghci%s-", prefixId),
+		NamePrefix:         fmt.Sprintf("ghci%s%s-", prid, prefixId),
 		ResourceGroupName:  strings.Join(gid, ""),
 		StorageAccountName: fmt.Sprintf("ghci%s", strings.Join(storageId, "")),
 	}


### PR DESCRIPTION
## Description

Add a possibility to enrich the `name_prefix` parameter with a PR ID

## Motivation and Context

When PR number is passed as `PRID` env. variable it will become part of the `name_prefix`. This way it's easier to identify all resources belonging to a particular PR and created during tests. It makes it also possible selectively delete resources when cleaning up after a failed CI.

## How Has This Been Tested?

Tested on a copy of Azure repo.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->


- New feature (non-breaking change which adds functionality)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.