### PR TITLE
feat: Add function to generate random names for AWS

### DIFF
--- a/pkg/testskeleton/testskeleton.go
+++ b/pkg/testskeleton/testskeleton.go
@@ -65,7 +65,7 @@ type AwsRandomNames struct {
 
 // Function that generates and returns a set of random AWS resource names.
 // Randomization is based on UUID.
-func GenerateAwRandomNames() AzureRandomNames {
+func GenerateAwRandomNames() AwsRandomNames {
 	prid := os.Getenv("PRID")
 	if prid != "" {
 		prid = fmt.Sprintf("-pr%s-", prid)

--- a/pkg/testskeleton/testskeleton.go
+++ b/pkg/testskeleton/testskeleton.go
@@ -68,7 +68,9 @@ type AwsRandomNames struct {
 func GenerateAwRandomNames() AwsRandomNames {
 	prid := os.Getenv("PRID")
 	if prid != "" {
-		prid = fmt.Sprintf("-pr%s-", prid)
+		prid = fmt.Sprintf("pr%s", prid)
+	} else {
+		prid = "tt"
 	}
 
 	id := uuid.New().String()
@@ -77,7 +79,7 @@ func GenerateAwRandomNames() AwsRandomNames {
 	prefixId := idSliced[2]
 
 	names := AwsRandomNames{
-		NamePrefix: fmt.Sprintf("tt%s%s-", prid, prefixId),
+		NamePrefix: fmt.Sprintf("%s-%s-", prid, prefixId),
 	}
 
 	return names

--- a/pkg/testskeleton/testskeleton.go
+++ b/pkg/testskeleton/testskeleton.go
@@ -58,6 +58,31 @@ type AdditionalChangesAfterDeployment struct {
 	ChangedResources     []ChangedResource
 }
 
+// Structure used for AWS deployments - contains randomly generated resource names.
+type AwsRandomNames struct {
+	NamePrefix string
+}
+
+// Function that generates and returns a set of random AWS resource names.
+// Randomization is based on UUID.
+func GenerateAwRandomNames() AzureRandomNames {
+	prid := os.Getenv("PRID")
+	if prid != "" {
+		prid = fmt.Sprintf("-pr%s-", prid)
+	}
+
+	id := uuid.New().String()
+	idSliced := strings.Split(id, "-")
+
+	prefixId := idSliced[2]
+
+	names := AwsRandomNames{
+		NamePrefix: fmt.Sprintf("tt%s%s-", prid, prefixId),
+	}
+
+	return names
+}
+
 // Structure used for Azure deployments - contains randomly generated resource names.
 type AzureRandomNames struct {
 	NamePrefix         string


### PR DESCRIPTION
## Description

PR delivers new function to generate random names for AWS.

## Motivation and Context

PR was prepared in order to simplify code for tests in AWS for VM-Series.

## How Has This Been Tested?

Code was tested by running tests in internal clone of `terraform-aws-vmseries-modules`.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.