### PR TITLE
fix: For PR make prefix shorten by 1 letter

### DIFF
--- a/pkg/testskeleton/testskeleton.go
+++ b/pkg/testskeleton/testskeleton.go
@@ -68,7 +68,7 @@ type AwsRandomNames struct {
 func GenerateAwRandomNames() AwsRandomNames {
 	prid := os.Getenv("PRID")
 	if prid != "" {
-		prid = fmt.Sprintf("pr%s", prid)
+		prid = fmt.Sprintf("p%s", prid)
 	} else {
 		prid = "tt"
 	}


### PR DESCRIPTION
## Description

PR delivers fix for AWS VM-Series modules as for some resources in AWS examples names cannot be longer than 32 characters.

## Motivation and Context

Issue with names longer than 32 was detected while doing https://github.com/PaloAltoNetworks/terraform-aws-vmseries-modules/actions/runs/6221685571

## How Has This Been Tested?

Code was tested on local machine.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.