### PR TITLE
fix(ci): Updated extra_plugins params for semantic release to work with sha pins

### DIFF
--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -18,10 +18,10 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
     - name: Set up Go
-      uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
       with:
         go-version: '1.20.x'
 

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -16,11 +16,11 @@ jobs:
       rc: ${{ steps.rc.outputs.new_release_published }}
     steps:
       - name: checkout code
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: dry-run sem versioning
         id: rc
-        uses: cycjimmy/semantic-release-action@8e58d20d0f6c8773181f43eb74d6a05e3099571d # v3
+        uses: cycjimmy/semantic-release-action@0a51e81a6baff2acad3ee88f4121c589c73d0f0e # v4
         with:
           dry_run: true
           semantic_version: 19.0
@@ -46,10 +46,10 @@ jobs:
       issues: read
     steps:
       - name: checkout repo
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Create release and publish
-        uses: cycjimmy/semantic-release-action@8e58d20d0f6c8773181f43eb74d6a05e3099571d # v3
+        uses: cycjimmy/semantic-release-action@0a51e81a6baff2acad3ee88f4121c589c73d0f0e # v4
         with:
           semantic_version: 19.0
           extra_plugins: |

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -3,7 +3,7 @@ name: Release CI
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 1 * * 4' # this means every Thursday @1am UTC
+    - cron: "0 1 * * 4" # this means every Thursday @1am UTC
 
 jobs:
   release-prereqs:
@@ -25,8 +25,8 @@ jobs:
           dry_run: true
           semantic_version: 19.0
           extra_plugins: |
-            conventional-changelog-conventionalcommits@^5.0.0
-            @semantic-release/git@^10.0.1
+            https://gitpkg.vercel.app/conventional-changelog/conventional-changelog/packages/conventional-changelog-conventionalcommits?ba6df7cf62de5f448368bed4398f6ddf633d2cbd
+            semantic-release/git#3e934d45f97fd07a63617c0fc098c9ed3e67d97a
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -53,7 +53,7 @@ jobs:
         with:
           semantic_version: 19.0
           extra_plugins: |
-            conventional-changelog-conventionalcommits@^5.0.0
-            @semantic-release/git@^10.0.1
+            https://gitpkg.vercel.app/conventional-changelog/conventional-changelog/packages/conventional-changelog-conventionalcommits?ba6df7cf62de5f448368bed4398f6ddf633d2cbd
+            semantic-release/git#3e934d45f97fd07a63617c0fc098c9ed3e67d97a
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Updated extra_plugins pinning to GitHub (instead of NPM Registry) within semantic release action:

```yaml
      - name: sem release
        id: rc
        uses: cycjimmy/semantic-release-action@0a51e81a6baff2acad3ee88f4121c589c73d0f0e # v4
        with:
          semantic_version: 19.0
          extra_plugins: |
            https://gitpkg.vercel.app/conventional-changelog/conventional-changelog/packages/conventional-changelog-conventionalcommits?ba6df7cf62de5f448368bed4398f6ddf633d2cbd
            semantic-release/git#3e934d45f97fd07a63617c0fc098c9ed3e67d97a
```

Also, bumping GH Actions versions to v4 similarly to CI Workflows repo.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

GitHub Actions pinning on all repos.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.